### PR TITLE
Update TargetFramework to net10.0 and bump all dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>net10.0</TargetFramework>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1021;CA1062;CA1724;SA1414;</WarningsNotAsErrors>
+    <WarningsNotAsErrors>CA1021;CA1062;CA1724;SA1414;</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724</WarningsNotAsErrors>
   </PropertyGroup>
@@ -31,11 +31,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All"/>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.0.2" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All"/>
+    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="All"/>
     <!-- It appears as though there might be a performance issue in versions of Microsoft.VisualStudio.Threading.Analyzers past this at least through 17.0.64 -->
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.9.60" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>net10.0</TargetFramework>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724</WarningsNotAsErrors>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1021;CA1062;CA1724;SA1414;</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Statiq.Web.Examples/Statiq.Web.Examples.csproj
+++ b/examples/Statiq.Web.Examples/Statiq.Web.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
 

--- a/src/Statiq.Web.Aws/Statiq.Web.Aws.csproj
+++ b/src/Statiq.Web.Aws/Statiq.Web.Aws.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine AmazonWebServices AWS</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <Choose>

--- a/src/Statiq.Web.Azure/DeploySearchIndex.cs
+++ b/src/Statiq.Web.Azure/DeploySearchIndex.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Azure.Search;
-using Microsoft.Azure.Search.Models;
+using Azure;
 using Microsoft.Extensions.Logging;
 using Polly;
 using Statiq.Common;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes;
+using Azure.Search.Documents.Indexes.Models;
+using Azure.Search.Documents.Models;
 
 namespace Statiq.Web.Azure
 {
@@ -41,7 +40,7 @@ namespace Statiq.Web.Azure
             Config<string> searchServiceName,
             Config<string> indexName,
             Config<string> apiKey,
-            Config<IEnumerable<Field>> fields)
+            Config<IEnumerable<SearchField>> fields)
             : base(
                 new Dictionary<string, IConfig>
                 {
@@ -59,70 +58,67 @@ namespace Statiq.Web.Azure
             string searchServiceName = values.GetString(SearchServiceName) ?? throw new ExecutionException("Invalid search service name");
             string indexName = values.GetString(IndexName) ?? throw new ExecutionException("Invalid search index name");
             string apiKey = values.GetString(ApiKey) ?? throw new ExecutionException("Invalid search API key");
-            IList<Field> fields = values.GetList<Field>(Fields)?.ToList() ?? throw new ExecutionException("Invalid search fields");
+            IList<SearchField> fields = values.GetList<SearchField>(Fields)?.ToList() ?? throw new ExecutionException("Invalid search fields");
 
-            SearchServiceClient client = new SearchServiceClient(searchServiceName, new SearchCredentials(apiKey));
-
-            // Delete the index if it currently exists (recreating is the easiest way to update it)
-            CorsOptions corsOptions = null;
-            if (await client.Indexes.ExistsAsync(indexName, null, context.CancellationToken))
+            if (!Uri.TryCreate(searchServiceName, UriKind.Absolute, out Uri searchServiceUri))
             {
-                // Get the CORS options because we'll need to recreate those
-                Microsoft.Azure.Search.Models.Index existingIndex = await client.Indexes.GetAsync(indexName, null, context.CancellationToken);
-                corsOptions = existingIndex.CorsOptions;
-
-                // Delete the existing index
-                context.LogDebug($"Deleting existing search index {indexName}");
-                await client.Indexes.DeleteAsync(indexName, null, null, context.CancellationToken);
+                throw new ExecutionException("Invalid search service name");
             }
 
+            SearchIndexClient searchIndexClient = new SearchIndexClient(searchServiceUri, new AzureKeyCredential(apiKey));
+
             // Create the index
-            Microsoft.Azure.Search.Models.Index index = new Microsoft.Azure.Search.Models.Index
+            SearchIndex index = new SearchIndex(indexName)
             {
-                Name = indexName,
                 Fields = fields,
-                CorsOptions = corsOptions
             };
             context.LogDebug($"Creating search index {indexName}");
-            await client.Indexes.CreateAsync(index, null, context.CancellationToken);
+            await searchIndexClient.CreateOrUpdateIndexAsync(index, true, true, context.CancellationToken);
 
             // Upload the documents to the search index in batches
             context.LogDebug($"Uploading {context.Inputs.Length} documents to search index {indexName}...");
-            ISearchIndexClient indexClient = client.Indexes.GetClient(indexName);
+            SearchClient indexClient = searchIndexClient.GetSearchClient(indexName);
             int start = 0;
             do
             {
                 // Create the dynamic search documents and batch
-                IndexAction<Microsoft.Azure.Search.Models.Document>[] indexActions = context.Inputs
+                IndexDocumentsAction<SearchDocument>[] indexActions = context.Inputs
                     .Skip(start)
                     .Take(BatchSize)
                     .Select(doc =>
                     {
-                        Microsoft.Azure.Search.Models.Document searchDocument = new Microsoft.Azure.Search.Models.Document();
-                        foreach (Field field in fields)
+                        SearchDocument searchDocument = new SearchDocument();
+                        foreach (SearchField field in fields)
                         {
                             if (doc.ContainsKey(field.Name))
                             {
                                 searchDocument[field.Name] = doc.Get(field.Name);
                             }
                         }
-                        return IndexAction.Upload(searchDocument);
+
+                        return IndexDocumentsAction.Upload(searchDocument);
                     })
                     .ToArray();
-                IndexBatch<Microsoft.Azure.Search.Models.Document> indexBatch = IndexBatch.New(indexActions);
+                IndexDocumentsBatch<SearchDocument> indexBatch = IndexDocumentsBatch.Create(indexActions);
 
                 // Upload the batch with exponential retry for failures
                 await Policy
-                 .Handle<IndexBatchException>()
-                 .WaitAndRetryAsync(
-                    5,
-                    attempt =>
-                    {
-                        context.LogWarning($"Failure while uploading batch {(start / BatchSize) + 1}, retry number {attempt}");
-                        return TimeSpan.FromSeconds(Math.Pow(2, attempt));
-                    },
-                    (ex, _) => indexBatch = ((IndexBatchException)ex).FindFailedActionsToRetry(indexBatch, fields.Single(x => x.IsKey == true).Name))
-                 .ExecuteAsync(async ct => await indexClient.Documents.IndexAsync(indexBatch, null, ct), context.CancellationToken);
+                    .Handle<RequestFailedException>()
+                    .OrResult<IndexDocumentsResult>(r => r.Results.Any(result => !result.Succeeded))
+                    .WaitAndRetryAsync(
+                        5,
+                        attempt =>
+                        {
+                            context.LogWarning($"Failure while uploading batch {(start / BatchSize) + 1}, retry number {attempt}");
+                            return TimeSpan.FromSeconds(Math.Pow(2, attempt));
+                        },
+                        (ex, _) =>
+                        {
+                            IEnumerable<string> failedResults = ex.Result.Results.Where(r => !r.Succeeded).Select(result => result.Key);
+                            IEnumerable<IndexDocumentsAction<SearchDocument>> failedActions = indexActions.Where(action => action.Document.Keys.Any(key => failedResults.Contains(key)));
+                            indexBatch = IndexDocumentsBatch.Create(failedActions.ToArray());
+                        })
+                    .ExecuteAsync(async ct => await indexClient.IndexDocumentsAsync(indexBatch, null, ct), context.CancellationToken);
 
                 context.LogDebug($"Uploaded {start + indexActions.Length} documents to search index {indexName}");
                 start += 1000;

--- a/src/Statiq.Web.Azure/Statiq.Web.Azure.csproj
+++ b/src/Statiq.Web.Azure/Statiq.Web.Azure.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Azure AppService</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Search" Version="10.1.0" />
+    <PackageReference Include="Azure.Search.Documents" Version="11.2.1" />
     <PackageReference Include="Polly" Version="8.6.5" />
   </ItemGroup>
 

--- a/src/Statiq.Web.Azure/Statiq.Web.Azure.csproj
+++ b/src/Statiq.Web.Azure/Statiq.Web.Azure.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Search" Version="10.1.0" />
-    <PackageReference Include="Polly" Version="7.1.1" />
+    <PackageReference Include="Polly" Version="8.6.5" />
   </ItemGroup>
 
   <Choose>

--- a/src/Statiq.Web.GitHub/Statiq.Web.GitHub.csproj
+++ b/src/Statiq.Web.GitHub/Statiq.Web.GitHub.csproj
@@ -18,8 +18,8 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="0.46.0" />
-    <PackageReference Include="Polly" Version="7.1.1" />
+    <PackageReference Include="Octokit" Version="14.0.0" />
+    <PackageReference Include="Polly" Version="8.6.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Statiq.Web.Hosting/Statiq.Web.Hosting.csproj
+++ b/src/Statiq.Web.Hosting/Statiq.Web.Hosting.csproj
@@ -11,9 +11,9 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="wwwroot\livereload.js" />

--- a/src/Statiq.Web.Hosting/Statiq.Web.Hosting.csproj
+++ b/src/Statiq.Web.Hosting/Statiq.Web.Hosting.csproj
@@ -11,9 +11,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="wwwroot\livereload.js" />

--- a/src/Statiq.Web.Netlify/Statiq.Web.Netlify.csproj
+++ b/src/Statiq.Web.Netlify/Statiq.Web.Netlify.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetlifySharp" Version="1.1.0" />
+    <PackageReference Include="NetlifySharp" Version="1.1.1" />
   </ItemGroup>
 
   <Choose>

--- a/src/Statiq.Web.Netlify/Statiq.Web.Netlify.csproj
+++ b/src/Statiq.Web.Netlify/Statiq.Web.Netlify.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="NetlifySharp" Version="1.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <Choose>

--- a/src/Statiq.Web/IExecutionContextXrefExtensions.cs
+++ b/src/Statiq.Web/IExecutionContextXrefExtensions.cs
@@ -135,7 +135,7 @@ namespace Statiq.Web
                 .SelectMany(x => context.Outputs.FromPipeline(x).Select(y => (PipelineName: x, Document: y)))
                 .Select(x => (x.Document.GetString(WebKeys.Xref), x))
                 .Where(x => x.Item1 is object)
-                .GroupBy(x => x.Item1, x => x.Item2, StringComparer.OrdinalIgnoreCase)
+                .GroupBy(x => x.Item1, x => x.x, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(x => x.Key, x => (ICollection<(string, IDocument)>)x.ToArray(), StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/Statiq.Web/Statiq.Web.csproj
+++ b/src/Statiq.Web/Statiq.Web.csproj
@@ -12,6 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Buildalyzer.Workspaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Build" Version="18.0.2" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Statiq.Web/Statiq.Web.csproj
+++ b/src/Statiq.Web/Statiq.Web.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Buildalyzer.Workspaces" Version="4.1.2" />
+    <PackageReference Include="Buildalyzer.Workspaces" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Statiq.Web/Templates/Templates.cs
+++ b/src/Statiq.Web/Templates/Templates.cs
@@ -15,7 +15,9 @@ using Statiq.Yaml;
 
 namespace Statiq.Web
 {
+#pragma warning disable CA1710 // Rename to TemplatesDictionary or TemplatesCollection
     public class Templates : IReadOnlyList<Template>, IReadOnlyDictionary<string, Template>
+#pragma warning restore CA1710 // Rename to TemplatesDictionary or TemplatesCollection
     {
         private readonly List<KeyValuePair<string, Template>> _templates = new List<KeyValuePair<string, Template>>();
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,7 +5,7 @@
     <HasRuntimeOutput>true</HasRuntimeOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/tests/Statiq.Web.Hosting.Tests/Middleware/DefaultExtensionsMiddlewareTests.cs
+++ b/tests/Statiq.Web.Hosting.Tests/Middleware/DefaultExtensionsMiddlewareTests.cs
@@ -81,7 +81,8 @@ namespace Statiq.Web.Hosting.Tests.Middleware
             response.StatusCode.ShouldBe(System.Net.HttpStatusCode.NotFound);
             body.ShouldBe(string.Empty);
         }
-
+#pragma warning disable ASPDEPR004 // WebHostBuilder Obsolete - needs to be replaced with WebApplicationFactory
+#pragma warning disable ASPDEPR008 // WebHostBuilder Obsolete - needs to be replaced with WebApplicationFactory
         private TestServer GetServer(DefaultExtensionsOptions options) =>
             new TestServer(
                 new WebHostBuilder()

--- a/tests/Statiq.Web.Hosting.Tests/Middleware/DisableCacheMiddlewareTests.cs
+++ b/tests/Statiq.Web.Hosting.Tests/Middleware/DisableCacheMiddlewareTests.cs
@@ -29,7 +29,8 @@ namespace Statiq.Web.Hosting.Tests.Middleware
             response.Headers.GetValues("Pragma").ShouldContain("no-cache");
             response.Content.Headers.GetValues("Expires").ShouldContain("0");
         }
-
+#pragma warning disable ASPDEPR004 // WebHostBuilder Obsolete - needs to be replaced with WebApplicationFactory
+#pragma warning disable ASPDEPR008 // WebHostBuilder Obsolete - needs to be replaced with WebApplicationFactory
         private TestServer GetServer() => new TestServer(
             new WebHostBuilder()
                 .Configure(app => app.UseDisableCache()));

--- a/tests/Statiq.Web.Hosting.Tests/Middleware/ScriptInjectionMiddlewareTests.cs
+++ b/tests/Statiq.Web.Hosting.Tests/Middleware/ScriptInjectionMiddlewareTests.cs
@@ -45,7 +45,8 @@ namespace Statiq.Web.Hosting.Tests.Middleware
             // Then
             body.ShouldBe(AssemblyHelper.ReadEmbeddedWebFile("NonHtmlDocument.css"));
         }
-
+#pragma warning disable ASPDEPR004 // WebHostBuilder Obsolete - needs to be replaced with WebApplicationFactory
+#pragma warning disable ASPDEPR008 // WebHostBuilder Obsolete - needs to be replaced with WebApplicationFactory
         private TestServer GetServer() => new TestServer(
             new WebHostBuilder()
                 .Configure(app => app

--- a/tests/Statiq.Web.Hosting.Tests/Middleware/VirtualDirectoryMiddlewareTests.cs
+++ b/tests/Statiq.Web.Hosting.Tests/Middleware/VirtualDirectoryMiddlewareTests.cs
@@ -59,7 +59,8 @@ namespace Statiq.Web.Hosting.Tests.Middleware
             // Then
             response.StatusCode.ShouldBe(System.Net.HttpStatusCode.NotFound);
         }
-
+#pragma warning disable ASPDEPR004 // WebHostBuilder Obsolete - needs to be replaced with WebApplicationFactory
+#pragma warning disable ASPDEPR008 // WebHostBuilder Obsolete - needs to be replaced with WebApplicationFactory
         private TestServer GetServer(string virtualDirectory) => new TestServer(
             new WebHostBuilder()
                 .Configure(app => app

--- a/tests/Statiq.Web.Hosting.Tests/Statiq.Web.Hosting.Tests.csproj
+++ b/tests/Statiq.Web.Hosting.Tests/Statiq.Web.Hosting.Tests.csproj
@@ -14,8 +14,8 @@
     <ProjectReference Include="..\..\src\Statiq.Web.Hosting\Statiq.Web.Hosting.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.0.0" />  <!-- Required for GenerateEmbeddedFilesManifest task -->
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.1" />  <!-- Required for GenerateEmbeddedFilesManifest task -->
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="wwwroot\BasicHtmlDocument.html" />

--- a/tests/Statiq.Web.Tests/Statiq.Web.Tests.csproj
+++ b/tests/Statiq.Web.Tests/Statiq.Web.Tests.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Statiq.Web\Statiq.Web.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Credits
- @girlpunk for #1015 - included in this PR
- @neromix for #1022

## Summary
- Replaces `netcoreapp3.1` with `net10.0` as the target framework for the solution.
- Bumps all dependencies in the solution
- Removes Nuget package vulnerability suppressions.
- Adds suppressions for new warnings which would be time consuming to resolve or grow the size of the PR.
- Pins some transitive dependencies to remediate security issues.